### PR TITLE
Enable number density emulator in fits

### DIFF
--- a/sunbird/inference/pocomc.py
+++ b/sunbird/inference/pocomc.py
@@ -9,9 +9,20 @@ from sunbird.inference.base import BaseSampler
 class PocoMCSampler(BaseSampler):
     """PoCoMC sampler wrapper with optional ellipsoid prior support."""
 
-    def __init__(self, **kwargs):
-        """Initialize the PoCoMC sampler wrapper."""
+    def __init__(self, number_density_model=None, target_density=None, **kwargs):
+        """Initialize the PoCoMC sampler wrapper.
+        
+        Args:
+            number_density_model: Optional model that predicts number density from HOD parameters.
+            target_density: Optional minimum target number density threshold.
+            **kwargs: Additional arguments passed to BaseSampler.
+        """
         super().__init__(**kwargs)
+        self.number_density_model = number_density_model
+        self.target_density = target_density
+
+        if self.number_density_model is not None and self.target_density is not None:
+            self.logger.info(f"Applying number density constraint: predicted density >= {self.target_density}")
 
     def fill_params(self, theta):
         """Fill a parameter vector to include fixed parameters.
@@ -46,6 +57,74 @@ class PocoMCSampler(BaseSampler):
             params[i] = self.fill_params(theta)
         return params
 
+    def params_to_dict(self, params):
+        """Convert parameter array to dictionary.
+
+        Args:
+            params: Full parameter array (1D) or batch of arrays (2D).
+
+        Returns:
+            Dictionary mapping parameter names to values or arrays of values.
+        """
+        param_names = list(self.priors.keys())
+        params = np.asarray(params)
+
+        if params.ndim == 1:
+            # Single parameter vector
+            return {name: np.array([params[i]]) for i, name in enumerate(param_names)}
+        else:
+            # Batch of parameter vectors
+            return {name: params[:, i] for i, name in enumerate(param_names)}
+
+    def extract_cosmo_params(self, params):
+        """Extract cosmological parameters for ellipsoid prior.
+
+        Args:
+            params: Full parameter array or dictionary.
+
+        Returns:
+            Array of cosmological parameters in the correct order.
+        """
+        cosmo_param_names = ['omega_b', 'omega_cdm', 'sigma8_m', 'n_s', 'nrun', 'N_ur', 'w0_fld', 'wa_fld']
+        param_names = list(self.priors.keys())
+        
+        if isinstance(params, dict):
+            # Extract from dictionary
+            return np.array([params[name] for name in cosmo_param_names if name in params])
+        else:
+            # Extract from array by finding indices
+            params = np.asarray(params)
+            indices = [param_names.index(name) for name in cosmo_param_names if name in param_names]
+            if params.ndim == 1:
+                return params[indices]
+            else:
+                return params[:, indices]
+
+    def extract_hod_params(self, params):
+        """Extract HOD parameters for number density calculation.
+
+        Args:
+            params: Full parameter array or dictionary.
+
+        Returns:
+            Dictionary or array of HOD parameters (excluding cosmological parameters).
+        """
+        cosmo_param_names = ['omega_b', 'omega_cdm', 'sigma8_m', 'n_s', 'nrun', 'N_ur', 'w0_fld', 'wa_fld']
+        param_names = list(self.priors.keys())
+        hod_param_names = [name for name in param_names if name not in cosmo_param_names]
+        
+        if isinstance(params, dict):
+            # Return dictionary of HOD parameters
+            return {name: params[name] for name in hod_param_names if name in params}
+        else:
+            # Extract from array by finding indices
+            params = np.asarray(params)
+            indices = [param_names.index(name) for name in hod_param_names]
+            if params.ndim == 1:
+                return params[indices]
+            else:
+                return params[:, indices]
+
     def get_model_prediction(self, theta):
         """Return the model prediction for the given parameters.
 
@@ -55,10 +134,109 @@ class PocoMCSampler(BaseSampler):
         Returns:
             Model prediction as a NumPy array.
         """
-        pred = self.theory_model(x=theta, skip_output_inverse_transform=self.sample_in_transformed_space)
+        if not hasattr(self, '_use_dict_input'):
+            # First call - determine which input format the theory_model accepts
+            try:
+                theta_dict = self.params_to_dict(theta)
+                pred = self.theory_model(x=theta_dict)
+                self._use_dict_input = True  # Cache: dict input works
+            except (TypeError, ValueError, KeyError):
+                # Fallback to array input if dict not supported
+                pred = self.theory_model(x=theta)
+                self._use_dict_input = False  # Cache: use array input
+        else:
+            # Subsequent calls - use cached input format
+            if self._use_dict_input:
+                theta_dict = self.params_to_dict(theta)
+                pred = self.theory_model(x=theta_dict)
+            else:
+                pred = self.theory_model(x=theta)
+        
         if isinstance(pred, torch.Tensor):
             pred = pred.detach().numpy()
         return pred
+
+    def _check_density_constraint(self, params, batch=False):
+        """Check if parameters satisfy the number density constraint.
+
+        Args:
+            params: Full parameter array or batch.
+            batch: Whether this is a batch of parameters.
+
+        Returns:
+            For single sample: True if constraint satisfied, False otherwise.
+            For batch: Boolean mask where True means constraint is satisfied.
+        """
+        if self.number_density_model is None or self.target_density is None:
+            return True if not batch else np.ones(len(params), dtype=bool)
+        
+        with torch.no_grad():
+            predicted_density = self.number_density_model.get_prediction(torch.Tensor(params))
+            predicted_density = predicted_density.numpy()
+
+        # Flatten the prediction to 1D to handle different output shapes
+        predicted_density = predicted_density.ravel()
+        
+        if batch:
+            return predicted_density >= self.target_density
+        else:
+            return predicted_density[0] >= self.target_density
+
+    def _compute_data_log_likelihood(self, params, valid_mask=None):
+        """Compute the data log likelihood term.
+
+        Args:
+            params: Full parameter array or batch.
+            valid_mask: Optional boolean mask for batch processing (only compute for True entries).
+
+        Returns:
+            Log likelihood value(s) from data comparison.
+        """
+        prediction = self.get_model_prediction(params)
+        diff = self.observation - prediction
+        
+        batch = len(params.shape) > 1
+        if batch:
+            if valid_mask is not None:
+                # Only compute for valid samples
+                logl = np.full(len(params), -np.inf)
+                valid_indices = np.where(valid_mask)[0]
+                logl[valid_indices] = np.asarray([-0.5 * diff[i] @ self.precision_matrix @ diff[i].T for i in valid_indices])
+            else:
+                logl = np.asarray([-0.5 * diff[i] @ self.precision_matrix @ diff[i].T for i in range(len(params))])
+        else:
+            logl = -0.5 * diff @ self.precision_matrix @ diff.T
+        
+        return logl
+
+    def _apply_ellipsoid_prior(self, params, logl, valid_mask=None):
+        """Apply the ellipsoid prior to the log likelihood.
+
+        Args:
+            params: Full parameter array or batch.
+            logl: Current log likelihood value(s).
+            valid_mask: Optional boolean mask for batch processing.
+
+        Returns:
+            Log likelihood with ellipsoid prior added.
+        """
+        if not self.ellipsoid:
+            return logl
+        
+        cosmo_params = self.extract_cosmo_params(params)
+        batch = len(params.shape) > 1
+        
+        if batch:
+            ellipsoid_logl = np.asarray([self.abacus_ellipsoid.log_likelihood(cosmo_params[i]) for i in range(len(params))])
+            if valid_mask is not None:
+                # Only add to valid samples
+                logl[valid_mask] += ellipsoid_logl[valid_mask]
+            else:
+                logl += ellipsoid_logl
+        else:
+            logl += self.abacus_ellipsoid.log_likelihood(cosmo_params)
+        
+        return logl
 
     def log_likelihood(self, theta):
         """Compute the log likelihood for a parameter vector or batch.
@@ -71,16 +249,27 @@ class PocoMCSampler(BaseSampler):
         """
         batch = len(theta.shape) > 1
         params = self.fill_params_batch(theta) if batch else self.fill_params(theta)
-        prediction = self.get_model_prediction(params)
-        diff = self.observation - prediction
+        
+        # Check density constraint
+        density_valid = self._check_density_constraint(params, batch=batch)
+        
         if batch:
-            logl = np.asarray([-0.5 * diff[i] @ self.precision_matrix @ diff[i].T for i in range(len(theta))])
-            if self.ellipsoid:
-                logl += np.asarray([self.abacus_ellipsoid.log_likelihood(params[i, :8]) for i in range(len(theta))])
+            # Early exit if all samples fail density constraint
+            if not np.any(density_valid):
+                return np.full(len(theta), -np.inf)
+            # Compute data likelihood (only for valid samples if constraint applied)
+            valid_mask = density_valid if (self.number_density_model is not None) else None
+            logl = self._compute_data_log_likelihood(params, valid_mask=valid_mask)
+            # Apply ellipsoid prior
+            logl = self._apply_ellipsoid_prior(params, logl, valid_mask=valid_mask)
         else:
-            logl = -0.5 * diff @ self.precision_matrix @ diff.T
-            if self.ellipsoid:
-                logl += self.abacus_ellipsoid.log_likelihood(params[:8])
+            # Early exit if density constraint fails
+            if not density_valid:
+                return -np.inf
+            # Compute data likelihood and apply ellipsoid prior
+            logl = self._compute_data_log_likelihood(params)
+            logl = self._apply_ellipsoid_prior(params, logl)
+        
         return logl
 
     def __call__(
@@ -141,17 +330,29 @@ class PocoMCPriorSampler(PocoMCSampler):
         super().__init__(observation, precision_matrix, theory_model, **kwargs)
 
     def log_likelihood(self, theta):
-        """Return a flat log likelihood with optional ellipsoid term."""
+        """Return a flat log likelihood with optional density and ellipsoid constraints."""
         batch = len(theta.shape) > 1
         params = self.fill_params_batch(theta) if batch else self.fill_params(theta)
+        
+        # Check density constraint
+        density_valid = self._check_density_constraint(params, batch=batch)
+        
         if batch:
+            # Initialize with flat likelihood
             logl = np.ones(len(theta))
-            if self.ellipsoid:
-                logl += np.asarray([self.abacus_ellipsoid.log_likelihood(params[i, :8]) for i in range(len(theta))])
+            # Set invalid samples to -inf
+            logl[~density_valid] = -np.inf
+            # Apply ellipsoid prior only to valid samples
+            valid_mask = density_valid if (self.number_density_model is not None) else None
+            logl = self._apply_ellipsoid_prior(params, logl, valid_mask=valid_mask)
         else:
-            logl  = 1.0 
-            if self.ellipsoid:
-                logl += self.abacus_ellipsoid.log_likelihood(params[:8])
+            # Early exit if density constraint fails
+            if not density_valid:
+                return -np.inf
+            # Start with flat likelihood and apply ellipsoid prior
+            logl = 1.0
+            logl = self._apply_ellipsoid_prior(params, logl)
+        
         return logl
 
 


### PR DESCRIPTION
This pull request adds support for optional number density constraints to the `PocoMCSampler` in `sunbird/inference/pocomc.py`, refactors likelihood computation for improved modularity, and introduces utility methods for parameter handling. The main changes enable the sampler to enforce a minimum predicted number density using a provided model, and to handle both array and dictionary parameter formats for flexible model input.

**Number Density Constraint Support:**
- Added `number_density_model` and `target_density` arguments to `PocoMCSampler`, allowing the sampler to enforce a minimum predicted number density during sampling. Logging is added to indicate when the constraint is active.
- Implemented `_check_density_constraint` to validate parameters against the density threshold, supporting both single and batch modes. [[1]](diffhunk://#diff-1e61a4f946add2a087802a3e87e89e40278c05c0efd7b5008fc3892d37828424L58-R240) [[2]](diffhunk://#diff-1e61a4f946add2a087802a3e87e89e40278c05c0efd7b5008fc3892d37828424L74-R272) [[3]](diffhunk://#diff-1e61a4f946add2a087802a3e87e89e40278c05c0efd7b5008fc3892d37828424L144-R355)

**Parameter Handling Utilities:**
- Added `params_to_dict`, `extract_cosmo_params`, and `extract_hod_params` methods to convert parameter arrays to dictionaries and extract cosmological or HOD parameters as needed for downstream processing.

**Likelihood Computation Refactor:**
- Refactored likelihood computation into modular methods: `_compute_data_log_likelihood` for the data term and `_apply_ellipsoid_prior` for adding the ellipsoid prior, both supporting batch and masking for valid samples.
- Updated `get_model_prediction` to automatically detect and cache whether the theory model expects parameters as a dictionary or array, improving compatibility and efficiency.

**Log Likelihood Logic Update:**
- Updated `log_likelihood` to enforce the density constraint and early-exit with `-np.inf` for invalid samples, both in the main and flat likelihood cases. The ellipsoid prior is now applied only to valid samples. [[1]](diffhunk://#diff-1e61a4f946add2a087802a3e87e89e40278c05c0efd7b5008fc3892d37828424L74-R272) [[2]](diffhunk://#diff-1e61a4f946add2a087802a3e87e89e40278c05c0efd7b5008fc3892d37828424L144-R355)