### PR TITLE
Lazy import wandb

### DIFF
--- a/sunbird/emulators/train.py
+++ b/sunbird/emulators/train.py
@@ -1,15 +1,27 @@
 import torch
-import wandb
 import logging
 import numpy as np
 from pathlib import Path
 # from warnings import deprecated # Available only in Python 3.13+
 from deprecation import deprecated
 from lightning import Trainer, seed_everything
-from lightning.pytorch.loggers import TensorBoardLogger, WandbLogger
+from lightning.pytorch.loggers.tensorboard import TensorBoardLogger
 from lightning.pytorch.callbacks import ModelCheckpoint, EarlyStopping, LearningRateMonitor, RichProgressBar
 from sunbird.emulators import FCN
 from sunbird.data import ArrayDataModule
+
+
+def _create_wandb_logger():
+    try:
+        import wandb
+        from lightning.pytorch.loggers.wandb import WandbLogger
+    except ImportError as exc:
+        raise ImportError(
+            "wandb is only required when logger='wandb'. Install a compatible wandb/protobuf setup or use logger='tensorboard' instead."
+        ) from exc
+
+    wandb.init()
+    return WandbLogger(log_model="all", project="sunbird")
 
 class FCNTrainer(Trainer):
     """
@@ -120,8 +132,7 @@ class FCNTrainer(Trainer):
             Configured logger instance or None.
         """
         if logger == 'wandb':
-            wandb.init()
-            logger = WandbLogger(log_model="all", project="sunbird",)
+            logger = _create_wandb_logger()
         elif logger == 'tensorboard':
             logger = TensorBoardLogger(log_dir, name="optuna")
         elif logger is None:
@@ -371,8 +382,7 @@ def fit(data, model, early_stop_patience=30, early_stop_threshold=1.e-7, max_epo
     seed_everything(42, workers=True)
 
     if logger == 'wandb':
-        wandb.init()
-        logger = WandbLogger(log_model="all", project="sunbird",)
+        logger = _create_wandb_logger()
     elif logger == 'tensorboard':
         logger = TensorBoardLogger(log_dir, name="optuna")
     else:


### PR DESCRIPTION
This pull request refactors how the `wandb` logger is imported and initialized in `sunbird/emulators/train.py` to improve optional dependency handling and prevent import errors when `wandb` is not installed. This is motivated by people running into library compatibility issues in the latest cosmodesi environment. The main change is moving the `wandb` import and initialization into a helper function that's only called when needed.

**Optional Dependency Handling:**

* Introduced a new `_create_wandb_logger()` helper function that encapsulates the import and initialization of `wandb` and `WandbLogger`, raising a clear error if `wandb` is not installed. This prevents import errors unless `wandb` logging is explicitly requested.
* Updated both the `get_logger` function and the `fit` function to use `_create_wandb_logger()` when `logger == 'wandb'`, ensuring consistent and safe logger creation. [[1]](diffhunk://#diff-63c1636d9fabfad23507ee3f4c12a773f14943e3b8e120f5fa2d5caea2df4a75L123-R135) [[2]](diffhunk://#diff-63c1636d9fabfad23507ee3f4c12a773f14943e3b8e120f5fa2d5caea2df4a75L374-R385)
* Changed the import of `TensorBoardLogger` to a more specific import path (`lightning.pytorch.loggers.tensorboard`) for clarity and to avoid unnecessary imports.