### PR TITLE
Add new transformer architectures

### DIFF
--- a/sunbird/emulators/__init__.py
+++ b/sunbird/emulators/__init__.py
@@ -1,1 +1,1 @@
-from .models import FCN, FlaxFCN, Transformer
+from .models import FCN, FlaxFCN, Transformer, Zhong24Transformer

--- a/sunbird/emulators/models/__init__.py
+++ b/sunbird/emulators/models/__init__.py
@@ -2,3 +2,4 @@ from .base import BaseModel
 from .fcn import FCN
 from .fcn_flax import FlaxFCN
 from .transformer import Transformer
+from .zhong24_transformer import Zhong24Transformer

--- a/sunbird/emulators/models/zhong24_transformer.py
+++ b/sunbird/emulators/models/zhong24_transformer.py
@@ -1,7 +1,8 @@
 import numpy as np
 import torch
 from torch import Tensor, nn
-from typing import Optional
+from typing import Optional, Tuple
+from torch.optim.lr_scheduler import ReduceLROnPlateau
 
 from sunbird.emulators.loss import (
     GaussianNLoglike,
@@ -13,23 +14,61 @@ from sunbird.emulators.loss import (
 from sunbird.emulators.models import BaseModel
 
 
-class Transformer(BaseModel):
-    """Transformer encoder tailored to continuous-feature emulator regression."""
+class Zhong24TransformerBlock(nn.Module):
+    """Post-norm residual transformer block used by Zhong et al. (2024)."""
+
+    def __init__(
+        self,
+        d_model: int,
+        n_heads: int,
+        dim_feedforward: int,
+        dropout_rate: float,
+    ):
+        super().__init__()
+        self.attention = nn.MultiheadAttention(
+            embed_dim=d_model,
+            num_heads=n_heads,
+            dropout=dropout_rate,
+            batch_first=True,
+        )
+        self.attention_dropout = nn.Dropout(dropout_rate)
+        self.attention_norm = nn.LayerNorm(d_model)
+
+        self.feedforward = nn.Sequential(
+            nn.Linear(d_model, dim_feedforward),
+            nn.PReLU(),
+            nn.Dropout(dropout_rate),
+            nn.Linear(dim_feedforward, d_model),
+        )
+        self.feedforward_dropout = nn.Dropout(dropout_rate)
+        self.feedforward_norm = nn.LayerNorm(d_model)
+
+    def forward(self, tokens: Tensor) -> Tensor:
+        attended, _ = self.attention(tokens, tokens, tokens, need_weights=False)
+        tokens = self.attention_norm(tokens + self.attention_dropout(attended))
+        updates = self.feedforward(tokens)
+        return self.feedforward_norm(tokens + self.feedforward_dropout(updates))
+
+
+class Zhong24Transformer(BaseModel):
+    """EMC-tuned Zhong-style transformer architecture."""
 
     def __init__(
         self,
         n_input: int,
         n_output: int,
-        d_model: int = 128,
+        n_tokens: int = 10,
+        d_model: int = 96,
         n_heads: int = 4,
-        n_layers: int = 4,
-        dim_feedforward: int = 512,
-        dropout_rate: float = 0.0,
-        learning_rate: float = 1.0e-3,
-        scheduler_patience: int = 30,
+        n_layers: int = 2,
+        dim_feedforward: int = 192,
+        dropout_rate: float = 0.05,
+        learning_rate: float = 5.0e-4,
+        weight_decay: float = 1.0e-2,
+        scheduler_patience: int = 8,
         scheduler_factor: float = 0.5,
-        scheduler_threshold: float = 1.0e-6,
-        weight_decay: float = 0.0,
+        scheduler_threshold: float = 1.0e-4,
+        adam_betas: Tuple[float, float] = (0.9, 0.999),
         loss: str = "rmse",
         training: bool = True,
         mean_input: Optional[torch.Tensor] = None,
@@ -42,7 +81,7 @@ class Transformer(BaseModel):
         transform_output: Optional[callable] = None,
         coordinates: Optional[dict] = None,
         compression_matrix: Optional[torch.Tensor] = None,
-        model_type: str = "transformer",
+        model_type: str = "zhong24_transformer",
         *args,
         **kwargs,
     ):
@@ -54,16 +93,18 @@ class Transformer(BaseModel):
 
         self.n_input = n_input
         self.n_output = n_output
+        self.n_tokens = n_tokens
         self.d_model = d_model
         self.n_heads = n_heads
         self.n_layers = n_layers
         self.dim_feedforward = dim_feedforward
         self.dropout_rate = dropout_rate
         self.learning_rate = learning_rate
+        self.weight_decay = weight_decay
         self.scheduler_patience = scheduler_patience
         self.scheduler_factor = scheduler_factor
         self.scheduler_threshold = scheduler_threshold
-        self.weight_decay = weight_decay
+        self.adam_betas = adam_betas
         self.loss = loss
         self.coordinates = coordinates
         self.standarize_input = standarize_input
@@ -83,33 +124,21 @@ class Transformer(BaseModel):
         elif self.loss == "multivariate_learned_gaussian":
             self.n_output += (self.n_output * (self.n_output + 1)) // 2
 
-        self.feature_weight = nn.Parameter(torch.empty(n_input, d_model))
-        self.feature_bias = nn.Parameter(torch.empty(n_input, d_model))
-        self.feature_embedding = nn.Parameter(torch.empty(n_input, d_model))
-        self.cls_token = nn.Parameter(torch.empty(1, 1, d_model))
-        self.input_dropout = nn.Dropout(dropout_rate)
-
-        encoder_layer = nn.TransformerEncoderLayer(
-            d_model=d_model,
-            nhead=n_heads,
-            dim_feedforward=dim_feedforward,
-            dropout=dropout_rate,
-            activation="gelu",
-            batch_first=True,
-            norm_first=True,
+        self.embedding = nn.Linear(n_input, n_tokens * d_model)
+        self.embedding_activation = nn.PReLU()
+        self.embedding_dropout = nn.Dropout(dropout_rate)
+        self.blocks = nn.ModuleList(
+            [
+                Zhong24TransformerBlock(
+                    d_model=d_model,
+                    n_heads=n_heads,
+                    dim_feedforward=dim_feedforward,
+                    dropout_rate=dropout_rate,
+                )
+                for _ in range(n_layers)
+            ]
         )
-        self.encoder = nn.TransformerEncoder(
-            encoder_layer=encoder_layer,
-            num_layers=n_layers,
-            enable_nested_tensor=False,
-        )
-        self.head = nn.Sequential(
-            nn.LayerNorm(2 * d_model),
-            nn.Linear(2 * d_model, dim_feedforward),
-            nn.GELU(),
-            nn.Dropout(dropout_rate),
-            nn.Linear(dim_feedforward, self.n_output),
-        )
+        self.head = nn.Linear(n_tokens * d_model, self.n_output)
         self.reset_parameters()
 
         if training:
@@ -127,8 +156,34 @@ class Transformer(BaseModel):
     @property
     def flax_attributes(self):
         raise NotImplementedError(
-            "Transformer does not currently support Flax/JAX conversion."
+            "Zhong24Transformer does not currently support Flax/JAX conversion."
         )
+
+    def configure_optimizers(self):
+        optimizer = torch.optim.AdamW(
+            self.parameters(),
+            lr=self.learning_rate,
+            weight_decay=self.weight_decay,
+            betas=self.adam_betas,
+        )
+        scheduler = ReduceLROnPlateau(
+            optimizer,
+            mode="min",
+            patience=self.scheduler_patience,
+            factor=self.scheduler_factor,
+            threshold=self.scheduler_threshold,
+            threshold_mode="abs",
+            min_lr=1.0e-6,
+        )
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {
+                "scheduler": scheduler,
+                "monitor": "val_loss",
+                "interval": "epoch",
+                "frequency": 1,
+            },
+        }
 
     def register_stat_buffer(self, parameter_name, parameter, dim):
         if parameter is not None:
@@ -143,11 +198,7 @@ class Transformer(BaseModel):
             )
 
     def reset_parameters(self):
-        nn.init.xavier_uniform_(self.feature_weight)
-        nn.init.zeros_(self.feature_bias)
-        nn.init.normal_(self.feature_embedding, std=0.02)
-        nn.init.normal_(self.cls_token, std=0.02)
-        for module in self.head:
+        for module in self.modules():
             if isinstance(module, nn.Linear):
                 nn.init.xavier_uniform_(module.weight)
                 nn.init.zeros_(module.bias)
@@ -181,14 +232,6 @@ class Transformer(BaseModel):
         else:
             raise NotImplementedError(f"Loss {loss} not implemented")
 
-    def _tokenize(self, x: Tensor) -> Tensor:
-        feature_tokens = x.unsqueeze(-1) * self.feature_weight.unsqueeze(0)
-        feature_tokens = feature_tokens + self.feature_bias.unsqueeze(0)
-        feature_tokens = feature_tokens + self.feature_embedding.unsqueeze(0)
-        cls_token = self.cls_token.expand(x.shape[0], -1, -1)
-        tokens = torch.cat([cls_token, feature_tokens], dim=1)
-        return self.input_dropout(tokens)
-
     def forward(self, x: Tensor):
         squeeze_batch = x.ndim == 1
         if squeeze_batch:
@@ -199,12 +242,12 @@ class Transformer(BaseModel):
             mean_input = self.mean_input.to(x.device)
             x = (x - mean_input) / std_input
 
-        tokens = self._tokenize(x)
-        encoded = self.encoder(tokens)
-        cls_state = encoded[:, 0]
-        pooled_state = encoded[:, 1:].mean(dim=1)
-        summary_state = torch.cat([cls_state, pooled_state], dim=-1)
-        y_pred = self.head(summary_state)
+        tokens = self.embedding(x).reshape(x.shape[0], self.n_tokens, self.d_model)
+        tokens = self.embedding_dropout(self.embedding_activation(tokens))
+        for block in self.blocks:
+            tokens = block(tokens)
+
+        y_pred = self.head(tokens.reshape(tokens.shape[0], -1))
 
         if self.loss == "learned_gaussian":
             y_pred, y_var = torch.chunk(y_pred, 2, dim=-1)
@@ -258,8 +301,6 @@ class Transformer(BaseModel):
             std_output = self.std_output.to(x.device)
             mean_output = self.mean_output.to(x.device)
             y_pred = y_pred * std_output + mean_output
-        if self.loss == "learned_gaussian":
-            return self.loss_fct(y_pred, y, y_var)
-        if self.loss == "multivariate_learned_gaussian":
+        if self.loss in {"learned_gaussian", "multivariate_learned_gaussian"}:
             return self.loss_fct(y_pred, y, y_var)
         return self.loss_fct(y, y_pred)

--- a/sunbird/emulators/train.py
+++ b/sunbird/emulators/train.py
@@ -15,7 +15,14 @@ class FCNTrainer(Trainer):
     """
     Trainer class for Fully Connected Neural Network (FCN) models using PyTorch Lightning.
     """
-    def __init__(self, callbacks: list = None, logger: str = None, log_dir: str = None, **kwargs):
+    def __init__(
+        self,
+        callbacks: list = None,
+        logger: str = None,
+        log_dir: str = None,
+        tensorboard_name: str = 'tensorboard',
+        **kwargs,
+    ):
         """
         Initialize the FCNTrainer with specified callbacks and logger.
         
@@ -58,7 +65,11 @@ class FCNTrainer(Trainer):
             ]
             callbacks = [cb for cb in callbacks if cb is not None] # Remove None callbacks
             
-        logger = self.get_logger(logger=logger, log_dir=log_dir)
+        logger = self.get_logger(
+            logger=logger,
+            log_dir=log_dir,
+            tensorboard_name=tensorboard_name,
+        )
         
         gradient_clip_val = kwargs.pop('gradient_clip_val', 0.5)
         log_every_n_steps = kwargs.pop('log_every_n_steps', 1)
@@ -103,7 +114,11 @@ class FCNTrainer(Trainer):
         return best_val_loss
     
     @staticmethod
-    def get_logger(logger: str = None, log_dir: str = None):
+    def get_logger(
+        logger: str = None,
+        log_dir: str = None,
+        tensorboard_name: str = 'tensorboard',
+    ):
         """
         Get the logger instance based on the specified type.
         
@@ -123,7 +138,7 @@ class FCNTrainer(Trainer):
             wandb.init()
             logger = WandbLogger(log_model="all", project="sunbird",)
         elif logger == 'tensorboard':
-            logger = TensorBoardLogger(log_dir, name="optuna")
+            logger = TensorBoardLogger(log_dir, name=tensorboard_name)
         elif logger is None:
             logger = None
         return logger
@@ -219,6 +234,7 @@ def train_fcn(
     checkpoint_filename: str = '{epoch:02d}-{step}-{val_loss:.5f}',
     train_logger: str = None,
     log_dir: str = None,
+    tensorboard_name: str = 'tensorboard',
     return_trainer: bool = False,
     **kwargs,
 ) -> float|tuple[float, FCNTrainer]:
@@ -266,6 +282,8 @@ def train_fcn(
         Type of logger to use ('wandb', 'tensorboard', or None).
     log_dir : str | None
         Directory to save logs.
+    tensorboard_name : str
+        TensorBoard subdirectory name when ``train_logger='tensorboard'``.
     return_trainer: bool
         Whether to return the trainer instance along with the validation loss.
     **kwargs
@@ -330,6 +348,7 @@ def train_fcn(
     trainer = FCNTrainer(
         logger = train_logger,
         log_dir = log_dir,
+        tensorboard_name = tensorboard_name,
         checkpoint_dir = checkpoint_dir,
         checkpoint_filename = checkpoint_filename,
         **kwargs,
@@ -347,7 +366,18 @@ def train_fcn(
 
 
 @deprecated("Kept for compatibility, use train_fcn instead")
-def fit(data, model, early_stop_patience=30, early_stop_threshold=1.e-7, max_epochs=1_000, model_dir=None, log_dir=None, logger='wandb', **kwargs):
+def fit(
+    data,
+    model,
+    early_stop_patience=30,
+    early_stop_threshold=1.e-7,
+    max_epochs=1_000,
+    model_dir=None,
+    log_dir=None,
+    logger='wandb',
+    tensorboard_name='tensorboard',
+    **kwargs,
+):
     early_stop_callback = EarlyStopping(
         monitor="val_loss", 
         patience=early_stop_patience, 
@@ -374,7 +404,7 @@ def fit(data, model, early_stop_patience=30, early_stop_threshold=1.e-7, max_epo
         wandb.init()
         logger = WandbLogger(log_model="all", project="sunbird",)
     elif logger == 'tensorboard':
-        logger = TensorBoardLogger(log_dir, name="optuna")
+        logger = TensorBoardLogger(log_dir, name=tensorboard_name)
     else:
         logger=None
 

--- a/sunbird/summaries/base.py
+++ b/sunbird/summaries/base.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from flax.core.frozen_dict import freeze
 from typing import List, Optional, Union, Dict, Tuple
 from sunbird.data import transforms
-from sunbird.emulators import FCN, FlaxFCN
+from sunbird.emulators import FCN, FlaxFCN, Transformer, Zhong24Transformer
 from sunbird.data.data_utils import convert_selection_to_filters, convert_to_summary
 
 DEFAULT_PATH = Path(__file__).parent.parent.parent / "trained_models/best/"
@@ -133,12 +133,26 @@ class BaseSummary:
             Tuple[Union[torch.nn.Module, flax.linen.Module], Optional[jnp.array]]: model and flax parameters
         """
 
+        with open(path_to_model / "hparams.yaml") as f:
+            config = yaml.safe_load(f)
+        model_type = str(config.get("model_type", "fcn")).lower()
+
         if flax:
+            if model_type in {"transformer", "zhong24_transformer"}:
+                raise NotImplementedError(
+                    "Transformer summaries do not yet support Flax/JAX loading."
+                )
             nn_model, flax_params = FlaxFCN.from_folder(
                 path_to_model,
             )
         else:
-            nn_model = FCN.from_folder(
+            if model_type == "transformer":
+                model_cls = Transformer
+            elif model_type == "zhong24_transformer":
+                model_cls = Zhong24Transformer
+            else:
+                model_cls = FCN
+            nn_model = model_cls.from_folder(
                 path_to_model,
                 load_loss=False,
             )

--- a/tests/emulators/test_transformer.py
+++ b/tests/emulators/test_transformer.py
@@ -1,0 +1,152 @@
+import numpy as np
+import pytest
+import torch
+from types import MethodType
+
+from sunbird.emulators import Transformer
+
+
+def test_transformer_forward_returns_expected_shapes():
+    model = Transformer(
+        n_input=5,
+        n_output=3,
+        d_model=16,
+        n_heads=4,
+        n_layers=2,
+        dim_feedforward=32,
+        dropout_rate=0.0,
+        learning_rate=1.0e-3,
+        weight_decay=0.0,
+        loss="weighted_mae",
+        training=True,
+        mean_input=np.zeros(5),
+        std_input=np.ones(5),
+        mean_output=np.zeros(3),
+        std_output=np.ones(3),
+        covariance_matrix=np.eye(3),
+    )
+
+    y_pred, y_var = model.forward(torch.randn(7, 5))
+
+    assert y_pred.shape == (7, 3)
+    assert y_var.shape == (7, 3)
+
+
+def test_transformer_get_prediction_applies_output_rescaling():
+    model = Transformer(
+        n_input=4,
+        n_output=2,
+        d_model=8,
+        n_heads=2,
+        n_layers=1,
+        dim_feedforward=16,
+        dropout_rate=0.0,
+        loss="mae",
+        training=False,
+        mean_input=np.zeros(4),
+        std_input=np.ones(4),
+        mean_output=np.array([10.0, 20.0]),
+        std_output=np.array([2.0, 3.0]),
+    )
+
+    def fake_forward(self, x):
+        y = torch.ones((x.shape[0], 2), dtype=torch.float32, device=x.device)
+        return y, torch.zeros_like(y)
+
+    model.forward = MethodType(fake_forward, model)
+
+    prediction = model.get_prediction(torch.zeros((3, 4), dtype=torch.float32))
+
+    expected = torch.tensor([[12.0, 23.0]] * 3, dtype=torch.float32)
+    assert torch.allclose(prediction, expected)
+
+
+def test_transformer_get_prediction_accepts_single_feature_vector():
+    model = Transformer(
+        n_input=4,
+        n_output=2,
+        d_model=8,
+        n_heads=2,
+        n_layers=1,
+        dim_feedforward=16,
+        dropout_rate=0.0,
+        loss="mae",
+        training=False,
+        mean_input=np.zeros(4),
+        std_input=np.ones(4),
+        mean_output=np.array([10.0, 20.0]),
+        std_output=np.array([2.0, 3.0]),
+    )
+
+    def fake_forward(self, x):
+        y = torch.ones((x.shape[0], 2), dtype=torch.float32, device=x.device)
+        return y, torch.zeros_like(y)
+
+    model.forward = MethodType(fake_forward, model)
+
+    prediction = model.get_prediction(torch.zeros(4, dtype=torch.float32))
+
+    expected = torch.tensor([12.0, 23.0], dtype=torch.float32)
+    assert torch.allclose(prediction, expected)
+
+
+def test_transformer_compute_loss_uses_configured_loss():
+    model = Transformer(
+        n_input=3,
+        n_output=2,
+        d_model=8,
+        n_heads=2,
+        n_layers=1,
+        dim_feedforward=16,
+        dropout_rate=0.0,
+        loss="mae",
+        training=True,
+        standarize_output=False,
+        covariance_matrix=np.eye(2),
+    )
+
+    def fake_forward(self, x):
+        y = torch.ones((x.shape[0], 2), dtype=torch.float32, device=x.device)
+        return y, torch.zeros_like(y)
+
+    model.forward = MethodType(fake_forward, model)
+    batch = (
+        torch.zeros((4, 3), dtype=torch.float32),
+        torch.zeros((4, 2), dtype=torch.float32),
+    )
+
+    loss = model._compute_loss(batch=batch, batch_idx=0)
+
+    assert float(loss) == pytest.approx(1.0)
+
+
+def test_transformer_saves_model_type_in_hparams():
+    model = Transformer(
+        n_input=3,
+        n_output=2,
+        d_model=8,
+        n_heads=2,
+        n_layers=1,
+        dim_feedforward=16,
+        dropout_rate=0.0,
+        loss="mae",
+        training=True,
+        covariance_matrix=np.eye(2),
+    )
+
+    assert model.hparams["model_type"] == "transformer"
+
+
+def test_transformer_requires_divisible_model_width():
+    with pytest.raises(ValueError, match="must be divisible"):
+        Transformer(
+            n_input=3,
+            n_output=2,
+            d_model=10,
+            n_heads=4,
+            n_layers=1,
+            dim_feedforward=16,
+            dropout_rate=0.0,
+            loss="mae",
+            training=False,
+        )

--- a/tests/emulators/test_zhong24_transformer.py
+++ b/tests/emulators/test_zhong24_transformer.py
@@ -1,0 +1,164 @@
+import numpy as np
+import pytest
+import torch
+from types import MethodType
+from torch.optim import AdamW
+from torch.optim.lr_scheduler import ReduceLROnPlateau
+
+from sunbird.emulators import Zhong24Transformer
+
+
+def test_zhong24_transformer_forward_returns_expected_shapes():
+    model = Zhong24Transformer(
+        n_input=5,
+        n_output=3,
+        n_tokens=25,
+        d_model=20,
+        n_heads=4,
+        n_layers=2,
+        dim_feedforward=20,
+        dropout_rate=0.0,
+        learning_rate=5.0e-4,
+        weight_decay=1.0e-2,
+        loss="weighted_mae",
+        training=True,
+        mean_input=np.zeros(5),
+        std_input=np.ones(5),
+        mean_output=np.zeros(3),
+        std_output=np.ones(3),
+        covariance_matrix=np.eye(3),
+    )
+
+    y_pred, y_var = model.forward(torch.randn(7, 5))
+
+    assert y_pred.shape == (7, 3)
+    assert y_var.shape == (7, 3)
+
+
+def test_zhong24_transformer_get_prediction_applies_output_rescaling():
+    model = Zhong24Transformer(
+        n_input=4,
+        n_output=2,
+        d_model=20,
+        n_heads=4,
+        n_layers=1,
+        dim_feedforward=20,
+        dropout_rate=0.0,
+        loss="mae",
+        training=False,
+        mean_input=np.zeros(4),
+        std_input=np.ones(4),
+        mean_output=np.array([10.0, 20.0]),
+        std_output=np.array([2.0, 3.0]),
+    )
+
+    def fake_forward(self, x):
+        y = torch.ones((x.shape[0], 2), dtype=torch.float32, device=x.device)
+        return y, torch.zeros_like(y)
+
+    model.forward = MethodType(fake_forward, model)
+
+    prediction = model.get_prediction(torch.zeros((3, 4), dtype=torch.float32))
+
+    expected = torch.tensor([[12.0, 23.0]] * 3, dtype=torch.float32)
+    assert torch.allclose(prediction, expected)
+
+
+def test_zhong24_transformer_get_prediction_accepts_single_feature_vector():
+    model = Zhong24Transformer(
+        n_input=4,
+        n_output=2,
+        d_model=20,
+        n_heads=4,
+        n_layers=1,
+        dim_feedforward=20,
+        dropout_rate=0.0,
+        loss="mae",
+        training=False,
+        mean_input=np.zeros(4),
+        std_input=np.ones(4),
+        mean_output=np.array([10.0, 20.0]),
+        std_output=np.array([2.0, 3.0]),
+    )
+
+    def fake_forward(self, x):
+        y = torch.ones((x.shape[0], 2), dtype=torch.float32, device=x.device)
+        return y, torch.zeros_like(y)
+
+    model.forward = MethodType(fake_forward, model)
+
+    prediction = model.get_prediction(torch.zeros(4, dtype=torch.float32))
+
+    expected = torch.tensor([12.0, 23.0], dtype=torch.float32)
+    assert torch.allclose(prediction, expected)
+
+
+def test_zhong24_transformer_saves_model_type_in_hparams():
+    model = Zhong24Transformer(
+        n_input=3,
+        n_output=2,
+        d_model=20,
+        n_heads=4,
+        n_layers=1,
+        dim_feedforward=20,
+        dropout_rate=0.0,
+        loss="mae",
+        training=True,
+        covariance_matrix=np.eye(2),
+    )
+
+    assert model.hparams["model_type"] == "zhong24_transformer"
+
+
+def test_zhong24_transformer_uses_small_data_defaults():
+    model = Zhong24Transformer(
+        n_input=3,
+        n_output=2,
+        loss="mae",
+        training=False,
+    )
+
+    assert model.n_tokens == 10
+    assert model.d_model == 96
+    assert model.n_layers == 2
+    assert model.dim_feedforward == 192
+    assert model.dropout_rate == pytest.approx(0.05)
+    assert model.scheduler_patience == 8
+    assert model.scheduler_factor == pytest.approx(0.5)
+    assert model.scheduler_threshold == pytest.approx(1.0e-4)
+
+
+def test_zhong24_transformer_configure_optimizers_sets_scheduler():
+    model = Zhong24Transformer(
+        n_input=3,
+        n_output=2,
+        loss="mae",
+        training=False,
+        scheduler_patience=9,
+        scheduler_factor=0.25,
+        scheduler_threshold=2.0e-4,
+    )
+
+    config = model.configure_optimizers()
+
+    assert isinstance(config["optimizer"], AdamW)
+    assert config["lr_scheduler"]["monitor"] == "val_loss"
+    assert isinstance(config["lr_scheduler"]["scheduler"], ReduceLROnPlateau)
+    assert config["lr_scheduler"]["scheduler"].patience == 9
+    assert config["lr_scheduler"]["scheduler"].factor == pytest.approx(0.25)
+    assert config["lr_scheduler"]["scheduler"].threshold == pytest.approx(2.0e-4)
+
+
+def test_zhong24_transformer_requires_divisible_model_width():
+    with pytest.raises(ValueError, match="must be divisible"):
+        Zhong24Transformer(
+            n_input=3,
+            n_output=2,
+            d_model=22,
+            n_heads=4,
+            n_layers=1,
+            dim_feedforward=20,
+            dropout_rate=0.0,
+            loss="mae",
+            training=False,
+        )

--- a/tests/summaries/test_model_loading.py
+++ b/tests/summaries/test_model_loading.py
@@ -1,0 +1,135 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from sunbird.summaries.base import BaseSummary
+
+
+def test_load_model_dispatches_transformer_from_hparams(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    (tmp_path / "hparams.yaml").write_text("model_type: transformer\n")
+    sentinel_model = SimpleNamespace(eval=lambda: sentinel_model)
+
+    def unexpected(*args, **kwargs):
+        raise AssertionError("FCN path should not be used for transformer models.")
+
+    called = {}
+
+    def fake_from_folder(path_to_model, load_loss=False):
+        called["path_to_model"] = path_to_model
+        called["load_loss"] = load_loss
+        return sentinel_model
+
+    monkeypatch.setattr(
+        "sunbird.summaries.base.FCN.from_folder",
+        unexpected,
+    )
+    monkeypatch.setattr(
+        "sunbird.summaries.base.Transformer.from_folder",
+        fake_from_folder,
+    )
+
+    model, flax_params = BaseSummary.load_model(tmp_path, flax=False)
+
+    assert model is sentinel_model
+    assert flax_params is None
+    assert called == {
+        "path_to_model": tmp_path,
+        "load_loss": False,
+    }
+
+
+def test_load_model_rejects_flax_for_transformer(
+    tmp_path: Path,
+):
+    (tmp_path / "hparams.yaml").write_text("model_type: transformer\n")
+
+    with pytest.raises(NotImplementedError, match="Flax/JAX"):
+        BaseSummary.load_model(tmp_path, flax=True)
+
+
+def test_load_model_defaults_to_fcn_when_model_type_missing(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    (tmp_path / "hparams.yaml").write_text("n_hidden: [64, 64]\n")
+    sentinel_model = SimpleNamespace(eval=lambda: sentinel_model)
+    called = {}
+
+    def fake_from_folder(path_to_model, load_loss=False):
+        called["path_to_model"] = path_to_model
+        called["load_loss"] = load_loss
+        return sentinel_model
+
+    monkeypatch.setattr(
+        "sunbird.summaries.base.FCN.from_folder",
+        fake_from_folder,
+    )
+    monkeypatch.setattr(
+        "sunbird.summaries.base.Transformer.from_folder",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("Transformer path should not be used without model_type.")
+        ),
+    )
+
+    model, flax_params = BaseSummary.load_model(tmp_path, flax=False)
+
+    assert model is sentinel_model
+    assert flax_params is None
+    assert called == {
+        "path_to_model": tmp_path,
+        "load_loss": False,
+    }
+
+
+def test_load_model_dispatches_zhong24_transformer_from_hparams(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    (tmp_path / "hparams.yaml").write_text("model_type: zhong24_transformer\n")
+    sentinel_model = SimpleNamespace(eval=lambda: sentinel_model)
+
+    called = {}
+
+    def fake_from_folder(path_to_model, load_loss=False):
+        called["path_to_model"] = path_to_model
+        called["load_loss"] = load_loss
+        return sentinel_model
+
+    monkeypatch.setattr(
+        "sunbird.summaries.base.FCN.from_folder",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("FCN path should not be used for zhong24 transformer models.")
+        ),
+    )
+    monkeypatch.setattr(
+        "sunbird.summaries.base.Transformer.from_folder",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("Generic transformer path should not be used for zhong24 transformer models.")
+        ),
+    )
+    monkeypatch.setattr(
+        "sunbird.summaries.base.Zhong24Transformer.from_folder",
+        fake_from_folder,
+    )
+
+    model, flax_params = BaseSummary.load_model(tmp_path, flax=False)
+
+    assert model is sentinel_model
+    assert flax_params is None
+    assert called == {
+        "path_to_model": tmp_path,
+        "load_loss": False,
+    }
+
+
+def test_load_model_rejects_flax_for_zhong24_transformer(
+    tmp_path: Path,
+):
+    (tmp_path / "hparams.yaml").write_text("model_type: zhong24_transformer\n")
+
+    with pytest.raises(NotImplementedError, match="Flax/JAX"):
+        BaseSummary.load_model(tmp_path, flax=True)


### PR DESCRIPTION
This pull request adds a new transformer model architecture inspired by Zhong et al. (2024) to the emulator codebase and significantly refactors the existing `Transformer` model for improved flexibility, modularity, and feature support. The changes also update module imports to expose the new model.

**Key changes:**

### New model architecture

* Added a new `Zhong24Transformer` model in `zhong24_transformer.py`, implementing a post-norm residual transformer block and an EMC-tuned architecture, including custom initialization, optimizer configuration, and support for various loss functions. This model is now available for import and use alongside existing models. [[1]](diffhunk://#diff-1b9ef5e682d84eda903045757ddf6e4cb5f2ad75ba3907ab3ce308b0a59fedcdR1-R306) [[2]](diffhunk://#diff-73a5618040305d8350bff9de95dc63095b5744a3b2ad02f23c508490b726331aR5) [[3]](diffhunk://#diff-3980e627ea6ccf25b21fff1829f837da062e09e6c2165633809fa900efeec3f1L1-R1)

### Transformer model refactor and enhancements

* Refactored the existing `Transformer` model in `transformer.py` for improved modularity, including:
  - More flexible and explicit constructor arguments for architecture and data handling.
  - Modular embedding/tokenization logic and head.
  - Support for input/output standardization, transformation, and compression.
  - Improved handling of uncertainty-aware and multivariate Gaussian losses.
  - Replaced deprecated/unused methods and attributes, and improved parameter initialization. [[1]](diffhunk://#diff-dec84a586875c1cdb7d461e2c443014eae00c554b0db2b01fec7566137a007e1L1-R113) [[2]](diffhunk://#diff-dec84a586875c1cdb7d461e2c443014eae00c554b0db2b01fec7566137a007e1R125-R169) [[3]](diffhunk://#diff-dec84a586875c1cdb7d461e2c443014eae00c554b0db2b01fec7566137a007e1L96-R263)

### Module import updates

* Updated `__init__.py` files to expose the new `Zhong24Transformer` model for external use. [[1]](diffhunk://#diff-3980e627ea6ccf25b21fff1829f837da062e09e6c2165633809fa900efeec3f1L1-R1) [[2]](diffhunk://#diff-73a5618040305d8350bff9de95dc63095b5744a3b2ad02f23c508490b726331aR5)

These changes enable easier experimentation with transformer-based emulator architectures and provide a more robust, extensible foundation for future development.