### PR TITLE
Add emulator checkpoint loader

### DIFF
--- a/sunbird/emulators/__init__.py
+++ b/sunbird/emulators/__init__.py
@@ -1,1 +1,2 @@
-from .models import FCN, FlaxFCN, Transformer, Zhong24Transformer
+from .loading import load_model_from_checkpoint
+from .models import BaseModel, FCN, FlaxFCN, Transformer, Zhong24Transformer

--- a/sunbird/emulators/loading.py
+++ b/sunbird/emulators/loading.py
@@ -1,0 +1,120 @@
+import logging
+import pickle
+from pathlib import Path
+from typing import Any, Dict, Optional, Type, Union
+
+import torch
+
+from sunbird.data.transforms_array import ArcsinhTransform, LogTransform
+from sunbird.emulators.models import BaseModel, FCN, Transformer, Zhong24Transformer
+
+logger = logging.getLogger(__name__)
+
+SAFE_GLOBALS = [LogTransform, ArcsinhTransform]
+MODEL_TYPES = {
+    "fcn": FCN,
+    "transformer": Transformer,
+    "zhong24_transformer": Zhong24Transformer,
+}
+
+
+def _is_weights_only_error(error: pickle.UnpicklingError) -> bool:
+    return "Weights only load failed" in str(error)
+
+
+def _register_safe_globals() -> None:
+    try:
+        torch.serialization.add_safe_globals(SAFE_GLOBALS)
+    except AttributeError:
+        logger.debug(
+            "torch.serialization.add_safe_globals is not available; "
+            "skipping safe globals registration."
+        )
+
+
+def _load_checkpoint_payload(checkpoint_fn: Union[Path, str]) -> Dict[str, Any]:
+    checkpoint_fn = Path(checkpoint_fn)
+    try:
+        return torch.load(checkpoint_fn, map_location=torch.device("cpu"))
+    except pickle.UnpicklingError as error:
+        if not _is_weights_only_error(error):
+            raise
+        logger.warning(
+            "Retrying checkpoint inspection with weights_only=False for %s "
+            "due to PyTorch weights-only unpickling restrictions.",
+            checkpoint_fn,
+        )
+        return torch.load(
+            checkpoint_fn,
+            map_location=torch.device("cpu"),
+            weights_only=False,
+        )
+
+
+def _get_model_class_from_checkpoint(
+    checkpoint_fn: Union[Path, str],
+) -> Type[BaseModel]:
+    checkpoint = _load_checkpoint_payload(checkpoint_fn)
+    hparams = checkpoint.get("hyper_parameters", {})
+    model_type = str(hparams.get("model_type", "fcn")).lower()
+    try:
+        return MODEL_TYPES[model_type]
+    except KeyError as error:
+        known_types = ", ".join(sorted(MODEL_TYPES))
+        raise ValueError(
+            f"Unknown emulator model_type '{model_type}' in checkpoint {checkpoint_fn}. "
+            f"Known types are: {known_types}."
+        ) from error
+
+
+def load_model_from_checkpoint(
+    checkpoint_fn: Union[Path, str],
+    model_cls: Optional[Type[BaseModel]] = None,
+    strict: bool = True,
+) -> BaseModel:
+    """
+    Load a Sunbird emulator model from a Lightning checkpoint.
+
+    Parameters
+    ----------
+    checkpoint_fn
+        Path to the model checkpoint file.
+    model_cls
+        Explicit model class to load. If not provided, the class is inferred from
+        ``hyper_parameters.model_type`` in the checkpoint, defaulting to FCN for
+        older checkpoints without ``model_type``.
+    strict
+        Whether to strictly enforce that the checkpoint keys match the model.
+
+    Returns
+    -------
+    BaseModel
+        The loaded model in evaluation mode on CPU.
+    """
+    checkpoint_fn = Path(checkpoint_fn)
+    _register_safe_globals()
+    if model_cls is None:
+        model_cls = _get_model_class_from_checkpoint(checkpoint_fn)
+
+    logger.info(
+        "Loading emulator model from %s with %s",
+        checkpoint_fn,
+        model_cls.__name__,
+    )
+    try:
+        model = model_cls.load_from_checkpoint(checkpoint_fn, strict=strict)
+    except pickle.UnpicklingError as error:
+        if not _is_weights_only_error(error):
+            raise
+        logger.warning(
+            "Retrying checkpoint load with weights_only=False for %s "
+            "due to PyTorch weights-only unpickling restrictions.",
+            checkpoint_fn,
+        )
+        model = model_cls.load_from_checkpoint(
+            checkpoint_fn,
+            strict=strict,
+            weights_only=False,
+        )
+    model.eval().to("cpu")
+    return model

--- a/tests/emulators/test_loading.py
+++ b/tests/emulators/test_loading.py
@@ -1,0 +1,217 @@
+import pickle
+from pathlib import Path
+
+import pytest
+import torch
+
+from sunbird.emulators import loading
+
+
+class LoadedModel:
+    def __init__(self):
+        self.eval_called = False
+        self.device = None
+
+    def eval(self):
+        self.eval_called = True
+        return self
+
+    def to(self, device):
+        self.device = device
+        return self
+
+
+def make_fake_model_class(calls):
+    class FakeModel:
+        __name__ = "FakeModel"
+
+        @classmethod
+        def load_from_checkpoint(cls, checkpoint_fn, strict=True, **kwargs):
+            calls.append(
+                {
+                    "checkpoint_fn": Path(checkpoint_fn),
+                    "strict": strict,
+                    "kwargs": kwargs,
+                }
+            )
+            return LoadedModel()
+
+    return FakeModel
+
+
+def test_load_model_from_checkpoint_uses_explicit_model_class(monkeypatch, tmp_path):
+    checkpoint_fn = tmp_path / "model.ckpt"
+    checkpoint_fn.write_bytes(b"not a torch checkpoint")
+    calls = []
+    fake_model_cls = make_fake_model_class(calls)
+
+    def unexpected_inspection(*args, **kwargs):
+        raise AssertionError("Explicit model_cls should skip checkpoint inspection.")
+
+    monkeypatch.setattr(loading, "_get_model_class_from_checkpoint", unexpected_inspection)
+
+    model = loading.load_model_from_checkpoint(
+        checkpoint_fn,
+        model_cls=fake_model_cls,
+        strict=False,
+    )
+
+    assert model.eval_called is True
+    assert model.device == "cpu"
+    assert calls == [
+        {
+            "checkpoint_fn": checkpoint_fn,
+            "strict": False,
+            "kwargs": {},
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    ("model_type", "model_key"),
+    [
+        ("fcn", "fcn"),
+        ("transformer", "transformer"),
+        ("zhong24_transformer", "zhong24_transformer"),
+    ],
+)
+def test_load_model_from_checkpoint_dispatches_from_model_type(
+    monkeypatch,
+    tmp_path,
+    model_type,
+    model_key,
+):
+    checkpoint_fn = tmp_path / "model.ckpt"
+    torch.save({"hyper_parameters": {"model_type": model_type}}, checkpoint_fn)
+    calls = []
+    fake_model_cls = make_fake_model_class(calls)
+    monkeypatch.setitem(loading.MODEL_TYPES, model_key, fake_model_cls)
+
+    model = loading.load_model_from_checkpoint(checkpoint_fn)
+
+    assert model.eval_called is True
+    assert model.device == "cpu"
+    assert calls == [
+        {
+            "checkpoint_fn": checkpoint_fn,
+            "strict": True,
+            "kwargs": {},
+        }
+    ]
+
+
+def test_load_model_from_checkpoint_defaults_missing_model_type_to_fcn(
+    monkeypatch,
+    tmp_path,
+):
+    checkpoint_fn = tmp_path / "model.ckpt"
+    torch.save({"hyper_parameters": {}}, checkpoint_fn)
+    calls = []
+    fake_model_cls = make_fake_model_class(calls)
+    monkeypatch.setitem(loading.MODEL_TYPES, "fcn", fake_model_cls)
+
+    loading.load_model_from_checkpoint(checkpoint_fn)
+
+    assert calls[0]["checkpoint_fn"] == checkpoint_fn
+
+
+def test_load_model_from_checkpoint_rejects_unknown_model_type(tmp_path):
+    checkpoint_fn = tmp_path / "model.ckpt"
+    torch.save({"hyper_parameters": {"model_type": "mystery"}}, checkpoint_fn)
+
+    with pytest.raises(ValueError, match="Unknown emulator model_type 'mystery'"):
+        loading.load_model_from_checkpoint(checkpoint_fn)
+
+
+def test_load_model_from_checkpoint_registers_safe_globals(monkeypatch, tmp_path):
+    checkpoint_fn = tmp_path / "model.ckpt"
+    checkpoint_fn.write_bytes(b"not a torch checkpoint")
+    calls = []
+    fake_model_cls = make_fake_model_class(calls)
+    registered = {}
+
+    def fake_add_safe_globals(safe_globals):
+        registered["safe_globals"] = safe_globals
+
+    monkeypatch.setattr(torch.serialization, "add_safe_globals", fake_add_safe_globals)
+
+    loading.load_model_from_checkpoint(checkpoint_fn, model_cls=fake_model_cls)
+
+    assert registered["safe_globals"] == loading.SAFE_GLOBALS
+
+
+def test_load_model_from_checkpoint_retries_weights_only_load(
+    monkeypatch,
+    tmp_path,
+):
+    checkpoint_fn = tmp_path / "model.ckpt"
+    checkpoint_fn.write_bytes(b"not a torch checkpoint")
+    calls = []
+
+    class FakeModel:
+        __name__ = "FakeModel"
+
+        @classmethod
+        def load_from_checkpoint(cls, checkpoint_fn, strict=True, **kwargs):
+            calls.append(
+                {
+                    "checkpoint_fn": Path(checkpoint_fn),
+                    "strict": strict,
+                    "kwargs": kwargs,
+                }
+            )
+            if len(calls) == 1:
+                raise pickle.UnpicklingError("Weights only load failed")
+            return LoadedModel()
+
+    model = loading.load_model_from_checkpoint(checkpoint_fn, model_cls=FakeModel)
+
+    assert model.eval_called is True
+    assert calls == [
+        {
+            "checkpoint_fn": checkpoint_fn,
+            "strict": True,
+            "kwargs": {},
+        },
+        {
+            "checkpoint_fn": checkpoint_fn,
+            "strict": True,
+            "kwargs": {"weights_only": False},
+        },
+    ]
+
+
+def test_load_model_from_checkpoint_retries_weights_only_inspection(
+    monkeypatch,
+    tmp_path,
+):
+    checkpoint_fn = tmp_path / "model.ckpt"
+    calls = []
+    model_calls = []
+    fake_model_cls = make_fake_model_class(model_calls)
+    monkeypatch.setitem(loading.MODEL_TYPES, "fcn", fake_model_cls)
+
+    def fake_torch_load(path, **kwargs):
+        calls.append({"path": Path(path), "kwargs": kwargs})
+        if len(calls) == 1:
+            raise pickle.UnpicklingError("Weights only load failed")
+        return {"hyper_parameters": {"model_type": "fcn"}}
+
+    monkeypatch.setattr(loading.torch, "load", fake_torch_load)
+
+    loading.load_model_from_checkpoint(checkpoint_fn)
+
+    assert calls == [
+        {
+            "path": checkpoint_fn,
+            "kwargs": {"map_location": torch.device("cpu")},
+        },
+        {
+            "path": checkpoint_fn,
+            "kwargs": {
+                "map_location": torch.device("cpu"),
+                "weights_only": False,
+            },
+        },
+    ]
+    assert model_calls[0]["checkpoint_fn"] == checkpoint_fn


### PR DESCRIPTION
This pull request adds a new utility for loading Sunbird emulator models from Lightning checkpoints, along with tests to ensure correct behavior. The main focus is on safely and flexibly loading models, handling different model types, and improving error handling for PyTorch checkpoint quirks.

**Key changes:**

### Model Loading Utility

* Added `load_model_from_checkpoint` in `sunbird/emulators/loading.py`, which loads emulator models from checkpoints, infers model class from checkpoint metadata, registers safe globals for PyTorch, and handles PyTorch-specific unpickling errors.
* Updated `sunbird/emulators/__init__.py` to expose `load_model_from_checkpoint` and `BaseModel` at the package level for easier imports.

### Error Handling and Compatibility

* Implemented logic to retry checkpoint loading with `weights_only=False` if the initial load fails due to PyTorch's weights-only unpickling restrictions.
* Registered custom transform classes as safe globals for PyTorch serialization, improving compatibility with custom checkpoint contents.

### Testing

* Added a comprehensive new test suite `tests/emulators/test_loading.py` covering explicit model class usage, model type inference, error handling, safe globals registration, and retry logic for weights-only loads.