### PR TITLE
Fix Abacus Summit cosmology table path

### DIFF
--- a/sunbird/inference/priors/abacus_summit.py
+++ b/sunbird/inference/priors/abacus_summit.py
@@ -1,4 +1,5 @@
 import numpy as np
+from pathlib import Path
 from scipy.linalg.lapack import dpotrf, dpotri
 
 class AbacusSummitEllipsoid:
@@ -78,7 +79,7 @@ class AbacusSummitEllipsoid:
 
     def summit_cosmo_table(self, params):
         import pandas
-        table_fn = "/global/cfs/cdirs/desicollab/users/epaillas/code/sunbird/sunbird/inference/priors/summit_cosmologies.txt"
+        table_fn = Path(__file__).with_name("summit_cosmologies.txt")
         df = pandas.read_csv(table_fn, delimiter=',')
         df.columns = df.columns.str.strip()
         df.columns = list(df.columns.str.strip('# ').values)


### PR DESCRIPTION
This pull request makes a minor update to how the `summit_cosmo_table` method locates the `summit_cosmologies.txt` file in the `AbacusSummitEllipsoid` class. Instead of using a hardcoded absolute path, it now uses a relative path based on the location of the Python file, improving portability and maintainability.

- Refactored file path handling:
  * Replaced the hardcoded absolute path to `summit_cosmologies.txt` with a relative path using `Path(__file__).with_name("summit_cosmologies.txt")` in the `summit_cosmo_table` method, making the code more robust to changes in file location.
  * Imported `Path` from the `pathlib` module to support the new file path logic.