### PR TITLE
Move git-installed deps to cosmodesi optional dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,9 +17,11 @@ Dependencies are listed in `pyproject.toml`, and installed automatically when in
 
 Optional dependencies can be added for the inference routines, with the following command:
 ```bash
-pip install sunbird[inference]
+pip install sunbird[cosmodesi,inference]
 ```
 
+> [!NOTE]
+> The `cosmodesi` dependencies contain dependencies existing on the `cosmodesi` environment at NERSC. When installing `sunbird` outside of NERSC, those dependencies are required.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,12 +26,10 @@ dependencies = [
     "torch",
     "lightning",
     "pytorch-lightning",
-    "jax",
     "flax",
     "joblib",
     "optuna",
     "deprecation",
-    'cosmoprimo[class,camb,astropy,extras] @ git+https://github.com/cosmodesi/cosmoprimo',
     "optax",
     "wandb",
     "mpi4py",
@@ -39,13 +37,17 @@ dependencies = [
 
 
 [project.optional-dependencies]
+cosmodesi = [ # Dependencies existing in the cosmodesi ecosystem
+    "jax",
+    "cosmoprimo[class,camb,astropy,extras] @ git+https://github.com/cosmodesi/cosmoprimo",
+    "desilike @ git+https://github.com/cosmodesi/desilike",
+]
 inference = [
     "matplotlib",
     "getdist",
     "tabulate",
-    "Py-BOBYQA",
-    "desilike @ git+https://github.com/cosmodesi/desilike",
     "h5py",
+    "Py-BOBYQA",
     "dynesty",
     "emcee",
     "numpyro",


### PR DESCRIPTION
Since git-collected dependencies can't be cached because there is no versioning, those are reinstalled each time we reinstall the package - which can take a significant time, especially for ACM test jobs on GitHub workers. This is especially true for our DESI-related packages, which also have git-collected dependencies.

Luckily, those git-collected dependencies are pre-installed in the `cosmodesi` NERSC environment, which allows us to create a `cosmodesi` optional dependency group (like what was done in `acm`)  to avoid installing them in the test environment :) 

This PR moves `desilike` and `cosmoprimo` (also `jax` just in case) to this new optional group